### PR TITLE
Add support for '.yaml' filename extension.

### DIFF
--- a/src/YamlLoader.php
+++ b/src/YamlLoader.php
@@ -38,9 +38,9 @@ class YamlLoader extends FileLoader
 
     public function supports($resource, $type = null)
     {
-        return is_string($resource) && 'yml' === pathinfo(
+        return is_string($resource) && in_array(pathinfo(
             $resource,
             PATHINFO_EXTENSION
-        );
+        ), ['yaml', 'yml'], true);
     }
 }


### PR DESCRIPTION
`.yaml` and `.yml` are [two valid extension filenames](https://en.wikipedia.org/wiki/YAML).
The [official](http://www.yaml.org/faq.html) is `.yaml`.