### PR TITLE
A syntax error fix and PHPUnit namespacing

### DIFF
--- a/tests/fixtures/invalid.php
+++ b/tests/fixtures/invalid.php
@@ -1,7 +1,7 @@
 <?php
 
 return array(
-    'operations' =
+    'operations' =>
         array(
             'certificates.add' =>
                 array(

--- a/tests/suite/JsonLoaderTest.php
+++ b/tests/suite/JsonLoaderTest.php
@@ -6,7 +6,7 @@ use Guzzle\Service\Loader\JsonLoader;
 
 use Symfony\Component\Config\FileLocator;
 
-class JsonLoaderTest extends \PHPUnit_Framework_TestCase
+class JsonLoaderTest extends \PHPUnit\Framework\TestCase
 {
     protected $jsonLoader;
 

--- a/tests/suite/PhpLoaderTest.php
+++ b/tests/suite/PhpLoaderTest.php
@@ -6,7 +6,7 @@ use Guzzle\Service\Loader\PhpLoader;
 
 use Symfony\Component\Config\FileLocator;
 
-class PhpLoaderTest extends \PHPUnit_Framework_TestCase
+class PhpLoaderTest extends \PHPUnit\Framework\TestCase
 {
     protected $PhpLoader;
 

--- a/tests/suite/YamlLoaderTest.php
+++ b/tests/suite/YamlLoaderTest.php
@@ -6,7 +6,7 @@ use Guzzle\Service\Loader\YamlLoader;
 
 use Symfony\Component\Config\FileLocator;
 
-class YamlLoaderTest extends \PHPUnit_Framework_TestCase
+class YamlLoaderTest extends \PHPUnit\Framework\TestCase
 {
     protected $YamlLoader;
 


### PR DESCRIPTION
The first commit is a syntax error fix. The operations key points to another array but had an equals sign instead of the array assignment operator.

The second commit is to fix the namespacing for the PHPUnit Test Case. I'm using PHP 7.2 and PHPUnit 7.1.2 and could not run the tests using the older style PHPUnit_Test_Case.